### PR TITLE
Integration of rollout code

### DIFF
--- a/DMS_preprocess.py
+++ b/DMS_preprocess.py
@@ -16,6 +16,28 @@ from com.rma.io import DssFileManagerImpl
 from com.rma.model import Project
 #import hec.hecmath.TimeSeriesMath as tsmath
 
+# create list of unwanted folders in sys.path
+search_list = ["SacTrn", "Sacramento", "American", "Stanislaus"]
+
+# initialize and search for unwanted paths
+matching_paths = []
+for p in sys.path:
+    if any(phrase in p for phrase in search_list):
+        matching_paths.append(p)
+
+# print paths containing unwanted phrases
+print("Paths to be removed:")
+for path in matching_paths:
+    print(path)
+
+# remove matching paths from sys.path
+for path in matching_paths:
+    if path in sys.path:
+        sys.path.remove(path)
+
+# append path
+sys.path.append(os.path.join(Project.getCurrentProject().getWorkspacePath(), "scripts"))
+
 from com.rma.io import DssFileManagerImpl
 from java.util import TimeZone
 

--- a/Forecast_preprocess.py
+++ b/Forecast_preprocess.py
@@ -15,6 +15,28 @@ from com.rma.io import DssFileManagerImpl
 from com.rma.model import Project
 #import hec.hecmath.TimeSeriesMath as tsmath
 
+# create list of unwanted folders in sys.path
+search_list = ["SacTrn", "Sacramento", "American", "Stanislaus"]
+
+# initialize and search for unwanted paths
+matching_paths = []
+for p in sys.path:
+    if any(phrase in p for phrase in search_list):
+        matching_paths.append(p)
+
+# print paths containing unwanted phrases
+print("Paths to be removed:")
+for path in matching_paths:
+    print(path)
+
+# remove matching paths from sys.path
+for path in matching_paths:
+    if path in sys.path:
+        sys.path.remove(path)
+
+# append path
+sys.path.append(os.path.join(Project.getCurrentProject().getWorkspacePath(), "scripts"))
+
 import DSS_Tools
 reload(DSS_Tools)
 
@@ -427,9 +449,6 @@ def write_forecast_elevations(currentAlternative, rtw, forecast_dss, shared_dir)
         start_dt = start_dt - dt.timedelta(days=1)
         start_str = start_dt.strftime('%d%b%Y')+ ' 2400'
     end_str = rtw.getEndTimeString()   
-    
-    print('Elevation times', start_str)
-    print('Elevation times', end_str)
 
     currentAlternative.addComputeMessage('Forecast Elevations: '+start_str+' '+end_str)
 

--- a/OutputLink_W2_Folsom-DownstreamAmer.py
+++ b/OutputLink_W2_Folsom-DownstreamAmer.py
@@ -344,11 +344,11 @@ def computeAlternative(currentAlternative, computeOptions):
     study_root = computeOptions.getRunDirectory()  # returns watershed directory
     
     # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
-    study_wat = study_root.split(os.sep)
-    study_wat = os.sep.join(study_wat[:-3])
+    study_main = study_root.split(os.sep)
+    study_main = os.sep.join(study_main[:-3])
     
     # Create the directory to the WAT simulation group
-    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    study_wat = study_main + os.sep + 'wat' + os.sep + 'simGroups'
     
     # Get the contents of the directory
     all_groups = os.listdir(study_wat)
@@ -358,9 +358,6 @@ def computeAlternative(currentAlternative, computeOptions):
     
     # Remove backup files not caught by the previous filter
     forecast_groups = [x for x in forecast_groups if '.bak' not in x]
-    
-    for x in forecast_groups:
-        currentAlternative.addComputeMessage("group name: " +  x)
     
     # Strip off the file extensions from each name
     forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
@@ -379,17 +376,19 @@ def computeAlternative(currentAlternative, computeOptions):
             break
     
     # Remove the group from the simulation name
-    currentAlternative.addComputeMessage("final group name: " +  x)
     alt_name = sim_name.split(group_name)[0]
     
-    # Remove the final dash that was not removed
+    # Remove the dash from the alternative name
     alt_name = alt_name[:-1]
-    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+    
+    # Construct the new simulation name that is the disk name
+    alt_name_underscore = alt_name.replace(' ', '_')
+    sim_name_underscore = alt_name_underscore + '-' + group_name
 
     ### Adjust the model name based on the alternative name ###
     # Get the current run directory
     run_dir = computeOptions.getRunDirectory()
-    
+
     # Start with the base model name. This is an assumed convention. 
     model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
     
@@ -404,7 +403,7 @@ def computeAlternative(currentAlternative, computeOptions):
         model_name += " NoBypass"
     
     ### Setup the paths ###
-    w2_run_dir = os.path.join(run_dir,'cequal-w2','Folsom',model_name)
+    w2_run_dir = os.path.join(study_main, 'runs', sim_name_underscore, 'CeQual-W2', 'Folsom', model_name)
     str_csv = os.path.join(w2_run_dir,'str_br1.csv')
     vol_file = os.path.join(w2_run_dir,'VOLUME_WB1.OPT')
     
@@ -447,16 +446,8 @@ def computeAlternative(currentAlternative, computeOptions):
 
     # Write out target temps and schedule number
     # ------------------------------------------------------------------------------------
-    run_dir = computeOptions.getRunDirectory() # runs/model_alt_name/scripting
-    model_name = 'W2 Folsom'  # base Folsom forecast model (iterative w/ bypass)
-    if "FixedATSP" in run_dir:
-        model_name += " FixedATSP"
-    if "NoBypass" in run_dir:
-        model_name += " NoBypass"
-    model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
-    run_base_dir,_ = os.path.split(run_dir)
-    model_run_dir_Folsom = os.path.join(run_base_dir,'CeQual-W2','Folsom',model_name)
-    shared_dir = os.path.join(fpp.study_dir_from_run_dir(run_dir),'shared')
+    model_run_dir_Folsom = w2_run_dir
+    shared_dir = os.path.join(study_main,'shared')
     forecast_dss = os.path.join(shared_dir,'WTMP_American_forecast.dss')
     
     # read AutoRunTempLog.opt and find last schedule used

--- a/OutputLink_W2_Folsom-DownstreamAmer.py
+++ b/OutputLink_W2_Folsom-DownstreamAmer.py
@@ -338,14 +338,72 @@ def computeAlternative(currentAlternative, computeOptions):
     startyear_str = starttime_str[5:9]
     year = int(startyear_str)
 
-    scripting_run_dir = computeOptions.getRunDirectory()
-    run_dir,_ = os.path.split(scripting_run_dir)
-    model_name = 'W2 Folsom'  # base Folsom forecast model (iterative w/ bypass)
-    if "FixedATSP" in run_dir:
+    ### Determine the alternative name ###
+    # This step is necessary to set the model up correctly based on American configurations
+    # Get the current folder
+    study_root = computeOptions.getRunDirectory()  # returns watershed directory
+    
+    # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
+    study_wat = study_root.split(os.sep)
+    study_wat = os.sep.join(study_wat[:-3])
+    
+    # Create the directory to the WAT simulation group
+    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    
+    # Get the contents of the directory
+    all_groups = os.listdir(study_wat)
+    
+    # Filter to only forecast groups
+    forecast_groups = [x for x in all_groups if ".fsimgrp" in x]
+    
+    # Remove backup files not caught by the previous filter
+    forecast_groups = [x for x in forecast_groups if '.bak' not in x]
+    
+    for x in forecast_groups:
+        currentAlternative.addComputeMessage("group name: " +  x)
+    
+    # Strip off the file extensions from each name
+    forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
+    
+    # Sort by the list decreasing
+    forecast_groups.sort(reverse=True)
+    
+    # Get the simulation name which is in alternative-simulation group format separated by a dash
+    sim_name = computeOptions.getSimulationName()
+    
+    # Loop and find the what forecast group is within the simulation name
+    for group_name in forecast_groups:
+        # Check if the group name is in the simulation name
+        if group_name in sim_name:
+            # Valid group name component has been found. Break to continue processing 
+            break
+    
+    # Remove the group from the simulation name
+    currentAlternative.addComputeMessage("final group name: " +  x)
+    alt_name = sim_name.split(group_name)[0]
+    
+    # Remove the final dash that was not removed
+    alt_name = alt_name[:-1]
+    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+
+    ### Adjust the model name based on the alternative name ###
+    # Get the current run directory
+    run_dir = computeOptions.getRunDirectory()
+    
+    # Start with the base model name. This is an assumed convention. 
+    model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
+    
+    # Check the alternative if the model needs adjustment for the fixed ATSP mode
+    if "FixedATSP" in alt_name:
+        # FixedATSP is found in the alternative name. Append it to the run directory
         model_name += " FixedATSP"
-    if "NoBypass" in run_dir:
+    
+    # Check the alternative if the model needs adjustment for the no bypass mode
+    if "NoBypass" in alt_name:
+        # NoBypass is found in the alternative name. Append it to the run directory
         model_name += " NoBypass"
-    #model_dir = fpp.model_dir_from_run_dir(scripting_run_dir,'Folsom',model_name)
+    
+    ### Setup the paths ###
     w2_run_dir = os.path.join(run_dir,'cequal-w2','Folsom',model_name)
     str_csv = os.path.join(w2_run_dir,'str_br1.csv')
     vol_file = os.path.join(w2_run_dir,'VOLUME_WB1.OPT')

--- a/Post-Process_W2_Fol-Nat.py
+++ b/Post-Process_W2_Fol-Nat.py
@@ -29,17 +29,17 @@ def computeAlternative(currentAlternative, computeOptions):
     startyear_str = starttime_str[5:9]
     year = int(startyear_str)
 
-### Determine the alternative name ###
+    ### Determine the alternative name ###
     # This step is necessary to set the model up correctly based on American configurations
     # Get the current folder
     study_root = computeOptions.getRunDirectory()  # returns watershed directory
     
     # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
-    study_wat = study_root.split(os.sep)
-    study_wat = os.sep.join(study_wat[:-3])
+    study_main = study_root.split(os.sep)
+    study_main = os.sep.join(study_main[:-3])
     
     # Create the directory to the WAT simulation group
-    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    study_wat = study_main + os.sep + 'wat' + os.sep + 'simGroups'
     
     # Get the contents of the directory
     all_groups = os.listdir(study_wat)
@@ -49,9 +49,6 @@ def computeAlternative(currentAlternative, computeOptions):
     
     # Remove backup files not caught by the previous filter
     forecast_groups = [x for x in forecast_groups if '.bak' not in x]
-    
-    for x in forecast_groups:
-        currentAlternative.addComputeMessage("group name: " +  x)
     
     # Strip off the file extensions from each name
     forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
@@ -70,17 +67,19 @@ def computeAlternative(currentAlternative, computeOptions):
             break
     
     # Remove the group from the simulation name
-    currentAlternative.addComputeMessage("final group name: " +  x)
     alt_name = sim_name.split(group_name)[0]
     
-    # Remove the final dash that was not removed
+    # Remove the dash from the alternative name
     alt_name = alt_name[:-1]
-    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+    
+    # Construct the new simulation name that is the disk name
+    alt_name_underscore = alt_name.replace(' ', '_')
+    sim_name_underscore = alt_name_underscore + '-' + group_name
 
     ### Adjust the model name based on the alternative name ###
     # Get the current run directory
     run_dir = computeOptions.getRunDirectory()
-    
+
     # Start with the base model name. This is an assumed convention. 
     model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
     
@@ -95,11 +94,9 @@ def computeAlternative(currentAlternative, computeOptions):
         model_name += " NoBypass"
     
     ### Setup the paths ###
-    model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
-    run_base_dir,_ = os.path.split(run_dir)
-    model_run_dir_Folsom = os.path.join(run_base_dir,'CeQual-W2','Folsom',model_name)
+    model_dir = os.path.join(study_main, 'runs', sim_name_underscore, 'CeQual-W2', 'Folsom', model_name)
     targt_temp_npt_filepath = os.path.join(model_dir,'TargetSchedulesA.npt') # overwrite what's there    
-    shared_dir = os.path.join(fpp.study_dir_from_run_dir(run_dir),'shared')
+    shared_dir = os.path.join(study_main,'shared')
     forecast_dss = os.path.join(shared_dir,'WTMP_American_forecast.dss')
     schedule_csv = os.path.join(model_dir,'SchedulesA.csv')
 

--- a/Post-Process_W2_Fol-Nat.py
+++ b/Post-Process_W2_Fol-Nat.py
@@ -29,12 +29,72 @@ def computeAlternative(currentAlternative, computeOptions):
     startyear_str = starttime_str[5:9]
     year = int(startyear_str)
 
-    run_dir = computeOptions.getRunDirectory() # runs/model_alt_name/scripting
-    model_name = 'W2 Folsom'  # base Folsom forecast model (iterative w/ bypass)
-    if "FixedATSP" in run_dir:
+### Determine the alternative name ###
+    # This step is necessary to set the model up correctly based on American configurations
+    # Get the current folder
+    study_root = computeOptions.getRunDirectory()  # returns watershed directory
+    
+    # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
+    study_wat = study_root.split(os.sep)
+    study_wat = os.sep.join(study_wat[:-3])
+    
+    # Create the directory to the WAT simulation group
+    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    
+    # Get the contents of the directory
+    all_groups = os.listdir(study_wat)
+    
+    # Filter to only forecast groups
+    forecast_groups = [x for x in all_groups if ".fsimgrp" in x]
+    
+    # Remove backup files not caught by the previous filter
+    forecast_groups = [x for x in forecast_groups if '.bak' not in x]
+    
+    for x in forecast_groups:
+        currentAlternative.addComputeMessage("group name: " +  x)
+    
+    # Strip off the file extensions from each name
+    forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
+    
+    # Sort by the list decreasing
+    forecast_groups.sort(reverse=True)
+    
+    # Get the simulation name which is in alternative-simulation group format separated by a dash
+    sim_name = computeOptions.getSimulationName()
+    
+    # Loop and find the what forecast group is within the simulation name
+    for group_name in forecast_groups:
+        # Check if the group name is in the simulation name
+        if group_name in sim_name:
+            # Valid group name component has been found. Break to continue processing 
+            break
+    
+    # Remove the group from the simulation name
+    currentAlternative.addComputeMessage("final group name: " +  x)
+    alt_name = sim_name.split(group_name)[0]
+    
+    # Remove the final dash that was not removed
+    alt_name = alt_name[:-1]
+    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+
+    ### Adjust the model name based on the alternative name ###
+    # Get the current run directory
+    run_dir = computeOptions.getRunDirectory()
+    
+    # Start with the base model name. This is an assumed convention. 
+    model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
+    
+    # Check the alternative if the model needs adjustment for the fixed ATSP mode
+    if "FixedATSP" in alt_name:
+        # FixedATSP is found in the alternative name. Append it to the run directory
         model_name += " FixedATSP"
-    if "NoBypass" in run_dir:
+    
+    # Check the alternative if the model needs adjustment for the no bypass mode
+    if "NoBypass" in alt_name:
+        # NoBypass is found in the alternative name. Append it to the run directory
         model_name += " NoBypass"
+    
+    ### Setup the paths ###
     model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
     run_base_dir,_ = os.path.split(run_dir)
     model_run_dir_Folsom = os.path.join(run_base_dir,'CeQual-W2','Folsom',model_name)

--- a/Post-Process_W2_Folsom.py
+++ b/Post-Process_W2_Folsom.py
@@ -44,11 +44,11 @@ def computeAlternative(currentAlternative, computeOptions):
     study_root = computeOptions.getRunDirectory()  # returns watershed directory
     
     # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
-    study_wat = study_root.split(os.sep)
-    study_wat = os.sep.join(study_wat[:-3])
+    study_main = study_root.split(os.sep)
+    study_main = os.sep.join(study_main[:-3])
     
     # Create the directory to the WAT simulation group
-    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    study_wat = study_main + os.sep + 'wat' + os.sep + 'simGroups'
     
     # Get the contents of the directory
     all_groups = os.listdir(study_wat)
@@ -58,9 +58,6 @@ def computeAlternative(currentAlternative, computeOptions):
     
     # Remove backup files not caught by the previous filter
     forecast_groups = [x for x in forecast_groups if '.bak' not in x]
-    
-    for x in forecast_groups:
-        currentAlternative.addComputeMessage("group name: " +  x)
     
     # Strip off the file extensions from each name
     forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
@@ -79,17 +76,19 @@ def computeAlternative(currentAlternative, computeOptions):
             break
     
     # Remove the group from the simulation name
-	currentAlternative.addComputeMessage("final group name: " +  x)
     alt_name = sim_name.split(group_name)[0]
     
-    # Remove the final dash that was not removed
+    # Remove the dash from the alternative name
     alt_name = alt_name[:-1]
-    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+    
+    # Construct the new simulation name that is the disk name
+    alt_name_underscore = alt_name.replace(' ', '_')
+    sim_name_underscore = alt_name_underscore + '-' + group_name
 
     ### Adjust the model name based on the alternative name ###
     # Get the current run directory
     run_dir = computeOptions.getRunDirectory()
-    
+
     # Start with the base model name. This is an assumed convention. 
     model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
     
@@ -104,11 +103,9 @@ def computeAlternative(currentAlternative, computeOptions):
         model_name += " NoBypass"
     
     ### Setup the paths ###
-    model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
-    run_base_dir,_ = os.path.split(run_dir)
-    model_run_dir_Folsom = os.path.join(run_base_dir,'CeQual-W2','Folsom',model_name)
+    model_dir = os.path.join(study_main, 'runs', sim_name_underscore, 'CeQual-W2', 'Folsom', model_name)
     targt_temp_npt_filepath = os.path.join(model_dir,'TargetSchedulesA.npt') # overwrite what's there    
-    shared_dir = os.path.join(fpp.study_dir_from_run_dir(run_dir),'shared')
+    shared_dir = os.path.join(study_main,'shared')
     forecast_dss = os.path.join(shared_dir,'WTMP_American_forecast.dss')
     schedule_csv = os.path.join(model_dir,'SchedulesA.csv')
 
@@ -139,7 +136,7 @@ def computeAlternative(currentAlternative, computeOptions):
         
     # read TEMP_LOG.OPT and find last schedule used (matching ensemble number if Schedules are loaded in WTMP as target temps)
     nSchedule = None
-    with open(os.path.join(model_run_dir_Folsom,'TEMP_LOG.OPT'),'r') as fp:
+    with open(os.path.join(model_dir,'TEMP_LOG.OPT'),'r') as fp:
         for line in fp.readlines():
             # the last schedule read in the file is the last (potentially iterative) schedule used
             if line.startswith("OPEN FILE:TargetSchedulesA.npt"):

--- a/Post-Process_W2_Folsom.py
+++ b/Post-Process_W2_Folsom.py
@@ -38,12 +38,72 @@ def computeAlternative(currentAlternative, computeOptions):
     startyear_str = starttime_str[5:9]
     year = int(startyear_str)
 
-    run_dir = computeOptions.getRunDirectory() # runs/model_alt_name/scripting
-    model_name = 'W2 Folsom'  # base Folsom forecast model (iterative w/ bypass)
-    if "FixedATSP" in run_dir:
+    ### Determine the alternative name ###
+    # This step is necessary to set the model up correctly based on American configurations
+    # Get the current folder
+    study_root = computeOptions.getRunDirectory()  # returns watershed directory
+    
+    # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
+    study_wat = study_root.split(os.sep)
+    study_wat = os.sep.join(study_wat[:-3])
+    
+    # Create the directory to the WAT simulation group
+    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    
+    # Get the contents of the directory
+    all_groups = os.listdir(study_wat)
+    
+    # Filter to only forecast groups
+    forecast_groups = [x for x in all_groups if ".fsimgrp" in x]
+    
+    # Remove backup files not caught by the previous filter
+    forecast_groups = [x for x in forecast_groups if '.bak' not in x]
+    
+    for x in forecast_groups:
+        currentAlternative.addComputeMessage("group name: " +  x)
+    
+    # Strip off the file extensions from each name
+    forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
+    
+    # Sort by the list decreasing
+    forecast_groups.sort(reverse=True)
+    
+    # Get the simulation name which is in alternative-simulation group format separated by a dash
+    sim_name = computeOptions.getSimulationName()
+    
+    # Loop and find the what forecast group is within the simulation name
+    for group_name in forecast_groups:
+        # Check if the group name is in the simulation name
+        if group_name in sim_name:
+            # Valid group name component has been found. Break to continue processing 
+            break
+    
+    # Remove the group from the simulation name
+	currentAlternative.addComputeMessage("final group name: " +  x)
+    alt_name = sim_name.split(group_name)[0]
+    
+    # Remove the final dash that was not removed
+    alt_name = alt_name[:-1]
+    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+
+    ### Adjust the model name based on the alternative name ###
+    # Get the current run directory
+    run_dir = computeOptions.getRunDirectory()
+    
+    # Start with the base model name. This is an assumed convention. 
+    model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
+    
+    # Check the alternative if the model needs adjustment for the fixed ATSP mode
+    if "FixedATSP" in alt_name:
+        # FixedATSP is found in the alternative name. Append it to the run directory
         model_name += " FixedATSP"
-    if "NoBypass" in run_dir:
+    
+    # Check the alternative if the model needs adjustment for the no bypass mode
+    if "NoBypass" in alt_name:
+        # NoBypass is found in the alternative name. Append it to the run directory
         model_name += " NoBypass"
+    
+    ### Setup the paths ###
     model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
     run_base_dir,_ = os.path.split(run_dir)
     model_run_dir_Folsom = os.path.join(run_base_dir,'CeQual-W2','Folsom',model_name)

--- a/Pre-Process_W2_Amer.py
+++ b/Pre-Process_W2_Amer.py
@@ -51,13 +51,73 @@ def computeAlternative(currentAlternative, computeOptions):
     endtime_str = rtw.getEndTimeString()
     startyear_str = starttime_str[5:9]
     year = int(startyear_str)
+    
+    ### Determine the alternative name ###
+    # This step is necessary to set the model up correctly based on American configurations
+    # Get the current folder
+    study_root = computeOptions.getRunDirectory()  # returns watershed directory
+    
+    # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
+    study_wat = study_root.split(os.sep)
+    study_wat = os.sep.join(study_wat[:-3])
+    
+    # Create the directory to the WAT simulation group
+    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    
+    # Get the contents of the directory
+    all_groups = os.listdir(study_wat)
+    
+    # Filter to only forecast groups
+    forecast_groups = [x for x in all_groups if ".fsimgrp" in x]
+    
+    # Remove backup files not caught by the previous filter
+    forecast_groups = [x for x in forecast_groups if '.bak' not in x]
+    
+    for x in forecast_groups:
+        currentAlternative.addComputeMessage("group name: " +  x)
+    
+    # Strip off the file extensions from each name
+    forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
+    
+    # Sort by the list decreasing
+    forecast_groups.sort(reverse=True)
+    
+    # Get the simulation name which is in alternative-simulation group format separated by a dash
+    sim_name = computeOptions.getSimulationName()
+    
+    # Loop and find the what forecast group is within the simulation name
+    for group_name in forecast_groups:
+        # Check if the group name is in the simulation name
+        if group_name in sim_name:
+            # Valid group name component has been found. Break to continue processing 
+            break
+    
+    # Remove the group from the simulation name
+	currentAlternative.addComputeMessage("final group name: " +  x)
+    alt_name = sim_name.split(group_name)[0]
+    
+    # Remove the final dash that was not removed
+    alt_name = alt_name[:-1]
+    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
 
+    ### Adjust the model name based on the alternative name ###
+    # Get the current run directory
     run_dir = computeOptions.getRunDirectory()
-    model_name = 'W2 Folsom'  # base Folsom forecast model (iterative w/ bypass)
-    if "FixedATSP" in run_dir:
+    
+    # Start with the base model name. This is an assumed convention. 
+    model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
+    
+    # Check the alternative if the model needs adjustment for the fixed ATSP mode
+    if "FixedATSP" in alt_name:
+        # FixedATSP is found in the alternative name. Append it to the run directory
         model_name += " FixedATSP"
-    if "NoBypass" in run_dir:
+    
+    # Check the alternative if the model needs adjustment for the no bypass mode
+    if "NoBypass" in alt_name:
+        # NoBypass is found in the alternative name. Append it to the run directory
         model_name += " NoBypass"
+    
+    ### Setup the paths ###
     model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
     targt_temp_npt_filepath = os.path.join(model_dir,'TargetSchedulesA.npt') # overwrite what's there    
     shared_dir = os.path.join(fpp.study_dir_from_run_dir(run_dir),'shared')

--- a/Pre-Process_W2_Amer.py
+++ b/Pre-Process_W2_Amer.py
@@ -58,11 +58,11 @@ def computeAlternative(currentAlternative, computeOptions):
     study_root = computeOptions.getRunDirectory()  # returns watershed directory
     
     # Split the path and strip off the scripts, alternative-group, and run folder to obtain the WAT directory
-    study_wat = study_root.split(os.sep)
-    study_wat = os.sep.join(study_wat[:-3])
+    study_main = study_root.split(os.sep)
+    study_main = os.sep.join(study_main[:-3])
     
     # Create the directory to the WAT simulation group
-    study_wat = study_wat + os.sep + 'wat' + os.sep + 'simGroups'
+    study_wat = study_main + os.sep + 'wat' + os.sep + 'simGroups'
     
     # Get the contents of the directory
     all_groups = os.listdir(study_wat)
@@ -72,9 +72,6 @@ def computeAlternative(currentAlternative, computeOptions):
     
     # Remove backup files not caught by the previous filter
     forecast_groups = [x for x in forecast_groups if '.bak' not in x]
-    
-    for x in forecast_groups:
-        currentAlternative.addComputeMessage("group name: " +  x)
     
     # Strip off the file extensions from each name
     forecast_groups = [x.split(".fsimgrp")[0] for x in forecast_groups]
@@ -93,17 +90,19 @@ def computeAlternative(currentAlternative, computeOptions):
             break
     
     # Remove the group from the simulation name
-	currentAlternative.addComputeMessage("final group name: " +  x)
     alt_name = sim_name.split(group_name)[0]
     
-    # Remove the final dash that was not removed
+    # Remove the dash from the alternative name
     alt_name = alt_name[:-1]
-    currentAlternative.addComputeMessage("Alternative name: " +  alt_name)  # log message  
+    
+    # Construct the new simulation name that is the disk name
+    alt_name_underscore = alt_name.replace(' ', '_')
+    sim_name_underscore = alt_name_underscore + '-' + group_name
 
     ### Adjust the model name based on the alternative name ###
     # Get the current run directory
     run_dir = computeOptions.getRunDirectory()
-    
+
     # Start with the base model name. This is an assumed convention. 
     model_name = "W2 Folsom"  # base Folsom forecast model (iterative w/ bypass)
     
@@ -118,9 +117,9 @@ def computeAlternative(currentAlternative, computeOptions):
         model_name += " NoBypass"
     
     ### Setup the paths ###
-    model_dir = fpp.model_dir_from_run_dir(run_dir,'Folsom',model_name)
+    model_dir = os.path.join(study_main, 'cequal-w2', 'Folsom', model_name)
     targt_temp_npt_filepath = os.path.join(model_dir,'TargetSchedulesA.npt') # overwrite what's there    
-    shared_dir = os.path.join(fpp.study_dir_from_run_dir(run_dir),'shared')
+    shared_dir = os.path.join(study_main,'shared')
     forecast_dss = os.path.join(shared_dir,'WTMP_American_forecast.dss')
     schedule_csv = os.path.join(model_dir,'SchedulesA.csv')
 

--- a/create_balance_flow_jython.py
+++ b/create_balance_flow_jython.py
@@ -263,11 +263,6 @@ def read_inflows_outflows(currentAlt, dss_file, inflow_records, outflow_records,
     for i in range(len(inflows[1:])):
         inflow_outflow.append(inflows[i+1] - outflows[i+1])
    # this is in cfs (period avg vals)
-   
-    print('Start str', starttime_str)
-    print('end str', endtime_str)
-    print('start hectime', starttime_hectime)
-    print('end hectime', endtime_hectime)
 
     currentAlt.addComputeMessage("Len inflow_outflow:"+str(len(inflow_outflow)))
     currentAlt.addComputeMessage("Len times:"+str(len(times)))
@@ -297,9 +292,6 @@ def predict_elevation(currentAlt, starttime_str, endtime_str, res_name, inflow_r
 
     times,inflow_outflow = read_inflows_outflows(currentAlt, dss_file, inflow_records, outflow_records, 
                                                  starttime_str, endtime_str, starttime_hectime, endtime_hectime)
-
-    print('start elevation series time:', times[0])
-    print('end elevation series time:', times[-1])
 
     currentAlt.addComputeMessage("Len inflow_outflow:"+str(len(inflow_outflow)))
     currentAlt.addComputeMessage("Len times:"+str(len(times)))


### PR DESCRIPTION
This pull request addresses, in part, Reclamation's third current priority to merge into the repository changes associated with the rollout package before beginning the next phase of development. These changes have been cherry picked to integrate with changes that were made in parallel to the rollout package.

I tested this by taking a previous study package, replacing the scripts directory, and running both the ResSim and W2 scenarios. This does require using current build to put values into the report templates. A good portion of the changes were associated with adding system and study path management, and that should not affect the core functionality. The study path code was generalized as the rollout code would trigger undesired behavior when either noATSP or NoBypass was included in the folder path or the simulation group names.

This merge is necessary but not sufficient to complete the rollout integration task. Remaining items include removing unneeded alternatives, merging any differences in alternatives into their respective RSS/W2 directories, and handling any differences in reports.